### PR TITLE
feat: run_guppy_module, add some tests

### DIFF
--- a/guppy_runner/__init__.py
+++ b/guppy_runner/__init__.py
@@ -4,6 +4,8 @@ import sys
 from argparse import ArgumentParser, Namespace
 from pathlib import Path
 
+from guppy.module import GuppyModule
+
 from guppy_runner.guppy_compiler import GuppyCompiler
 from guppy_runner.hugr_compiler import HugrCompiler
 from guppy_runner.mlir_compiler import MLIRCompiler
@@ -88,6 +90,47 @@ def run_guppy_str(  # noqa: PLR0913
         Stage.GUPPY,
         guppy_program,
         EncodingMode.TEXTUAL,
+    )
+
+    return run_guppy_from_stage(
+        stage_data,
+        hugr_out=hugr_out,
+        mlir_out=mlir_out,
+        llvm_out=llvm_out,
+        no_run=no_run,
+        module_name=module_name,
+    )
+
+
+def run_guppy_module(  # noqa: PLR0913
+    module: GuppyModule,
+    *,
+    hugr_out: Path | None = None,
+    mlir_out: Path | None = None,
+    llvm_out: Path | None = None,
+    no_run: bool = False,
+    module_name: str | None = None,
+) -> bool:
+    """Compile and run a Guppy program.
+
+    :param guppy_program: The Guppy program to run.
+    :param hugr_out: Optional. If provided, write the compiled Hugr to this file.
+        The file extension determines the encoding mode (json or msgpack).
+    :param mlir_out: Optional. If provided, write the compiled MLIR to this file.
+    :param llvm_out: Optional. If provided, write the compiled LLVMIR to this file.
+    :param no_run: Optional. If True, do not run the compiled artifact.
+        The compilation will terminate after producing the required intermediary files.
+    :param module_name: Optional. The name of the module to load. By default,
+        compiles the module used by @guppy.
+    :return: Whether the program ran successfully.
+    """
+    hugr = module.compile()
+    serial_hugr = hugr.serialize()
+
+    stage_data = StageData(
+        Stage.HUGR,
+        serial_hugr,
+        EncodingMode.BITCODE,
     )
 
     return run_guppy_from_stage(

--- a/poetry.lock
+++ b/poetry.lock
@@ -23,6 +23,17 @@ files = [
 ]
 
 [[package]]
+name = "colorama"
+version = "0.4.6"
+description = "Cross-platform colored terminal text."
+optional = false
+python-versions = "!=3.0.*,!=3.1.*,!=3.2.*,!=3.3.*,!=3.4.*,!=3.5.*,!=3.6.*,>=2.7"
+files = [
+    {file = "colorama-0.4.6-py2.py3-none-any.whl", hash = "sha256:4f1d9991f5acc0ca119f9d443620b77f9d6b33703e51011c16baf57afb285fc6"},
+    {file = "colorama-0.4.6.tar.gz", hash = "sha256:08695f5cb7ed6e0531a20572697297273c47b8cae5a63ffc6d6ed5c201be6e44"},
+]
+
+[[package]]
 name = "distlib"
 version = "0.3.8"
 description = "Distribution utilities"
@@ -102,6 +113,17 @@ files = [
 license = ["ukkonen"]
 
 [[package]]
+name = "iniconfig"
+version = "2.0.0"
+description = "brain-dead simple config-ini parsing"
+optional = false
+python-versions = ">=3.7"
+files = [
+    {file = "iniconfig-2.0.0-py3-none-any.whl", hash = "sha256:b6a85871a79d2e3b22d2d1b94ac2824226a63c6b741c88f7ae975f18b6778374"},
+    {file = "iniconfig-2.0.0.tar.gz", hash = "sha256:2d91e135bf72d31a410b17c16da610a82cb55f6b0477d1a902134b24a455b8b3"},
+]
+
+[[package]]
 name = "logging"
 version = "0.4.9.6"
 description = "A logging module for Python"
@@ -174,6 +196,17 @@ files = [
 ]
 
 [[package]]
+name = "packaging"
+version = "23.2"
+description = "Core utilities for Python packages"
+optional = false
+python-versions = ">=3.7"
+files = [
+    {file = "packaging-23.2-py3-none-any.whl", hash = "sha256:8c491190033a9af7e1d931d0b5dacc2ef47509b34dd0de67ed209b5203fc88c7"},
+    {file = "packaging-23.2.tar.gz", hash = "sha256:048fb0e9405036518eaaf48a55953c750c11e1a1b68e0dd1a9d62ed0c092cfc5"},
+]
+
+[[package]]
 name = "platformdirs"
 version = "4.1.0"
 description = "A small Python package for determining appropriate platform-specific dirs, e.g. a \"user data dir\"."
@@ -187,6 +220,21 @@ files = [
 [package.extras]
 docs = ["furo (>=2023.7.26)", "proselint (>=0.13)", "sphinx (>=7.1.1)", "sphinx-autodoc-typehints (>=1.24)"]
 test = ["appdirs (==1.4.4)", "covdefaults (>=2.3)", "pytest (>=7.4)", "pytest-cov (>=4.1)", "pytest-mock (>=3.11.1)"]
+
+[[package]]
+name = "pluggy"
+version = "1.3.0"
+description = "plugin and hook calling mechanisms for python"
+optional = false
+python-versions = ">=3.8"
+files = [
+    {file = "pluggy-1.3.0-py3-none-any.whl", hash = "sha256:d89c696a773f8bd377d18e5ecda92b7a3793cbe66c87060a6fb58c7b6e1061f7"},
+    {file = "pluggy-1.3.0.tar.gz", hash = "sha256:cf61ae8f126ac6f7c451172cf30e3e43d3ca77615509771b3a984a0730651e12"},
+]
+
+[package.extras]
+dev = ["pre-commit", "tox"]
+testing = ["pytest", "pytest-benchmark"]
 
 [[package]]
 name = "pre-commit"
@@ -361,6 +409,43 @@ all = ["twine (>=3.4.1)"]
 dev = ["twine (>=3.4.1)"]
 
 [[package]]
+name = "pytest"
+version = "7.4.4"
+description = "pytest: simple powerful testing with Python"
+optional = false
+python-versions = ">=3.7"
+files = [
+    {file = "pytest-7.4.4-py3-none-any.whl", hash = "sha256:b090cdf5ed60bf4c45261be03239c2c1c22df034fbffe691abe93cd80cea01d8"},
+    {file = "pytest-7.4.4.tar.gz", hash = "sha256:2cf0005922c6ace4a3e2ec8b4080eb0d9753fdc93107415332f50ce9e7994280"},
+]
+
+[package.dependencies]
+colorama = {version = "*", markers = "sys_platform == \"win32\""}
+iniconfig = "*"
+packaging = "*"
+pluggy = ">=0.12,<2.0"
+
+[package.extras]
+testing = ["argcomplete", "attrs (>=19.2.0)", "hypothesis (>=3.56)", "mock", "nose", "pygments (>=2.7.2)", "requests", "setuptools", "xmlschema"]
+
+[[package]]
+name = "pytest-env"
+version = "1.1.3"
+description = "pytest plugin that allows you to add environment variables."
+optional = false
+python-versions = ">=3.8"
+files = [
+    {file = "pytest_env-1.1.3-py3-none-any.whl", hash = "sha256:aada77e6d09fcfb04540a6e462c58533c37df35fa853da78707b17ec04d17dfc"},
+    {file = "pytest_env-1.1.3.tar.gz", hash = "sha256:fcd7dc23bb71efd3d35632bde1bbe5ee8c8dc4489d6617fb010674880d96216b"},
+]
+
+[package.dependencies]
+pytest = ">=7.4.3"
+
+[package.extras]
+test = ["covdefaults (>=2.3)", "coverage (>=7.3.2)", "pytest-mock (>=3.12)"]
+
+[[package]]
 name = "pyyaml"
 version = "6.0.1"
 description = "YAML parser and emitter for Python"
@@ -495,4 +580,4 @@ test = ["covdefaults (>=2.3)", "coverage (>=7.2.7)", "coverage-enable-subprocess
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.11"
-content-hash = "520699b28c2a343e04c102d4784f43d092e735f396c05bda6a631eba28b216b6"
+content-hash = "74912852583b0c77310d18457f87a69230a6c7cbb6a15cd34eab14460cd883c1"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,6 +15,8 @@ guppy = { git = "git@github.com:CQCL-DEV/guppy.git", rev = "ac4659c" }
 logging = "^0.4.9.6"
 
 [tool.poetry.group.dev.dependencies]
+pytest = "^7.4.4"
+pytest-env = "^1.1.3"
 pre-commit = ">=2.10"
 pyright = ">=1.1.345"
 ruff = ">=0.1.11"
@@ -22,6 +24,14 @@ ruff = ">=0.1.11"
 [tool.pyright]
 
 exclude = ["test_files"]
+
+[tool.pytest.ini_options]
+
+# TODO: Find a way to bundle these
+env = [
+    "HUGR_MLIR_TRANSLATE = ../hugr-mlir/_b/hugr-mlir/target/x86_64-unknown-linux-gnu/debug/hugr-mlir-translate",
+    "HUGR_MLIR_OPT = ../hugr-mlir/_b/bin/hugr-mlir-opt",
+]
 
 [build-system]
 requires = ["poetry-core"]

--- a/ruff.toml
+++ b/ruff.toml
@@ -83,6 +83,7 @@ ignore = [
     "ANN201",  # Missing return type annotation for public function
     "S101",    # Use of `assert` detected
     "PLR2004", # Magic value used in comparison, consider replacing * with a constant variable
+    "D103",    # Missing docstring in public function
 ]
 
 [pydocstyle]

--- a/tests/test_hugr.py
+++ b/tests/test_hugr.py
@@ -1,0 +1,55 @@
+"""Tests for the public API."""
+
+from pathlib import Path
+from tempfile import NamedTemporaryFile
+
+from guppy.decorator import guppy
+from guppy.module import GuppyModule
+
+from guppy_runner import run_guppy, run_guppy_module
+
+EVEN_ODD = "test_files/even_odd.py"
+
+
+def test_even_odd():
+    with NamedTemporaryFile(suffix=".hugr") as temp_hugr, NamedTemporaryFile(
+        suffix=".mlir",
+    ) as temp_mlir:
+        temp_hugr.close()
+        temp_mlir.close()
+
+        # Just check that it runs.
+        #
+        # We cannot load any of the artifacts with just the guppy library,
+        # so we have to assume that they are correct.
+        assert run_guppy(
+            EVEN_ODD,
+            hugr_out=Path(temp_hugr.name),
+            mlir_out=Path(temp_mlir.name),
+            # TODO: llvmir generation is broken
+            # llvm_out="test_files/even_odd.ll",  # noqa: ERA001
+            no_run=True,
+        )
+
+
+def test_from_module():
+    module = GuppyModule("module")
+
+    @guppy(module)
+    def main(x: bool) -> bool:  # noqa: FBT001
+        return x
+
+    with NamedTemporaryFile(suffix=".mlir") as temp_mlir:
+        temp_mlir.close()
+
+        # Just check that it runs.
+        #
+        # We cannot load any of the artifacts with just the guppy library,
+        # so we have to assume that they are correct.
+        assert run_guppy_module(
+            module,
+            mlir_out=Path(temp_mlir.name),
+            # TODO: llvmir generation is broken
+            # llvm_out="test_files/even_odd.ll",  # noqa: ERA001
+            no_run=True,
+        )


### PR DESCRIPTION
The tests use hardcoded paths to the compiler binaries for now.
That should be changed once we figure out how to distribute all the bundle.

Closes #6 