### PR TITLE
feat: Support bytecode llvmir output

### DIFF
--- a/guppy_runner/__main__.py
+++ b/guppy_runner/__main__.py
@@ -112,9 +112,9 @@ def parse_args() -> Namespace:
         "--store-llvm",
         type=Path,
         metavar="LLVM.ll",
-        help="Store the intermediary LLVMIR object, in textual mode.",
-        # TODO: Support bitcode too.
-        # Can we detect the encoding mode from the file extension?
+        help="Store the intermediary LLVMIR object."
+        "The file extension determines whether the file is encoded in textual (.ll) or "
+        "bytecode mode (.bc).",
     )
 
     # Runnable artifact options

--- a/guppy_runner/workflow.py
+++ b/guppy_runner/workflow.py
@@ -57,6 +57,10 @@ class EncodingMode(Enum):
             return EncodingMode.TEXTUAL
         if stage == Stage.MLIR and ext == ".mlir":
             return EncodingMode.TEXTUAL
+        if stage == Stage.LLVM and ext == ".bc":
+            return EncodingMode.BITCODE
+        if stage == Stage.LLVM and ext == ".ll":
+            return EncodingMode.TEXTUAL
         return None
 
     @staticmethod


### PR DESCRIPTION
Adds the "--emit-bytecode" flag to `hugr-mlir-opt` when storing llvmir in a ".bc" file.