### PR TITLE
Bump guppy. Rename guppy module -> guppylang

### DIFF
--- a/guppy_runner/__init__.py
+++ b/guppy_runner/__init__.py
@@ -4,7 +4,7 @@ import sys
 from argparse import ArgumentParser, Namespace
 from pathlib import Path
 
-from guppy.module import GuppyModule  # type: ignore
+from guppylang.module import GuppyModule  # type: ignore
 
 from guppy_runner.compile import CompilerError
 from guppy_runner.compile.guppy_compiler import GuppyCompiler

--- a/guppy_runner/compile/guppy_compiler.py
+++ b/guppy_runner/compile/guppy_compiler.py
@@ -4,7 +4,7 @@ import importlib.machinery
 import types
 from pathlib import Path
 
-from guppy.module import GuppyModule  # type: ignore
+from guppylang.module import GuppyModule  # type: ignore
 
 from guppy_runner.compile import CompilerError, StageCompiler
 from guppy_runner.stage import EncodingMode, Stage

--- a/poetry.lock
+++ b/poetry.lock
@@ -45,6 +45,20 @@ files = [
 ]
 
 [[package]]
+name = "exceptiongroup"
+version = "1.2.0"
+description = "Backport of PEP 654 (exception groups)"
+optional = false
+python-versions = ">=3.7"
+files = [
+    {file = "exceptiongroup-1.2.0-py3-none-any.whl", hash = "sha256:4bfd3996ac73b41e9b9628b04e079f193850720ea5945fc96a08633c66912f14"},
+    {file = "exceptiongroup-1.2.0.tar.gz", hash = "sha256:91f5c769735f051a4290d52edd0858999b57e5876e9f85937691bd4c9fa3ed68"},
+]
+
+[package.extras]
+test = ["pytest (>=6)"]
+
+[[package]]
 name = "filelock"
 version = "3.13.1"
 description = "A platform independent file lock."
@@ -77,7 +91,7 @@ docs = ["sphinx (>=5)", "sphinx-autodoc-typehints", "sphinx-rtd-theme"]
 test = ["coverage", "mock (>=4)", "pytest (>=7)", "pytest-cov", "pytest-mock (>=3)"]
 
 [[package]]
-name = "guppy"
+name = "guppylang"
 version = "0.1.0"
 description = ""
 optional = false
@@ -93,10 +107,8 @@ pydantic = "^2.5.3"
 typing-extensions = "^4.9.0"
 
 [package.source]
-type = "git"
-url = "git@github.com:CQCL-DEV/guppy.git"
-reference = "ac4659c"
-resolved_reference = "ac4659cd2e9a2cc023307d9c25ca38146f726469"
+type = "directory"
+url = "../guppy"
 
 [[package]]
 name = "identify"
@@ -421,9 +433,11 @@ files = [
 
 [package.dependencies]
 colorama = {version = "*", markers = "sys_platform == \"win32\""}
+exceptiongroup = {version = ">=1.0.0rc8", markers = "python_version < \"3.11\""}
 iniconfig = "*"
 packaging = "*"
 pluggy = ">=0.12,<2.0"
+tomli = {version = ">=1.0.0", markers = "python_version < \"3.11\""}
 
 [package.extras]
 testing = ["argcomplete", "attrs (>=19.2.0)", "hypothesis (>=3.56)", "mock", "nose", "pygments (>=2.7.2)", "requests", "setuptools", "xmlschema"]
@@ -441,6 +455,7 @@ files = [
 
 [package.dependencies]
 pytest = ">=7.4.3"
+tomli = {version = ">=2.0.1", markers = "python_version < \"3.11\""}
 
 [package.extras]
 test = ["covdefaults (>=2.3)", "coverage (>=7.3.2)", "pytest-mock (>=3.12)"]
@@ -547,6 +562,17 @@ testing = ["build[virtualenv]", "filelock (>=3.4.0)", "flake8-2020", "ini2toml[l
 testing-integration = ["build[virtualenv] (>=1.0.3)", "filelock (>=3.4.0)", "jaraco.envs (>=2.2)", "jaraco.path (>=3.2.0)", "packaging (>=23.1)", "pytest", "pytest-enabler", "pytest-xdist", "tomli", "virtualenv (>=13.0.0)", "wheel"]
 
 [[package]]
+name = "tomli"
+version = "2.0.1"
+description = "A lil' TOML parser"
+optional = false
+python-versions = ">=3.7"
+files = [
+    {file = "tomli-2.0.1-py3-none-any.whl", hash = "sha256:939de3e7a6161af0c887ef91b7d41a53e7c5a1ca976325f429cb46ea9bc30ecc"},
+    {file = "tomli-2.0.1.tar.gz", hash = "sha256:de526c12914f0c550d15924c62d72abc48d6fe7364aa87328337a31007fe8a4f"},
+]
+
+[[package]]
 name = "typing-extensions"
 version = "4.9.0"
 description = "Backported and Experimental Type Hints for Python 3.8+"
@@ -579,5 +605,5 @@ test = ["covdefaults (>=2.3)", "coverage (>=7.2.7)", "coverage-enable-subprocess
 
 [metadata]
 lock-version = "2.0"
-python-versions = "^3.11"
-content-hash = "74912852583b0c77310d18457f87a69230a6c7cbb6a15cd34eab14460cd883c1"
+python-versions = "^3.10"
+content-hash = "e116a077489208438de09bda7dd61b32b017a109cef04c7d644ed9fb666424b9"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,8 +10,8 @@ license = "Apache-2.0"
 guppy-runner = "guppy_runner.__main__:main"
 
 [tool.poetry.dependencies]
-python = "^3.11"
-guppy = { git = "git@github.com:CQCL-DEV/guppy.git", rev = "ac4659c" }
+python = "^3.10"
+guppy = { git = "git@github.com:CQCL-DEV/guppy.git", rev = "e0761ff" }
 logging = "^0.4.9.6"
 
 [tool.poetry.group.dev.dependencies]

--- a/test_files/even_odd.py
+++ b/test_files/even_odd.py
@@ -1,5 +1,5 @@
-from guppy.decorator import guppy
-from guppy.module import GuppyModule
+from guppylang.decorator import guppy
+from guppylang.module import GuppyModule
 
 module = GuppyModule("module")
 

--- a/tests/test_hugr.py
+++ b/tests/test_hugr.py
@@ -3,8 +3,8 @@
 from pathlib import Path
 from tempfile import NamedTemporaryFile
 
-from guppy.decorator import guppy  # type: ignore
-from guppy.module import GuppyModule  # type: ignore
+from guppylang.decorator import guppy  # type: ignore
+from guppylang.module import GuppyModule  # type: ignore
 
 from guppy_runner import run_guppy, run_guppy_module
 


### PR DESCRIPTION
Also loosen requirements on python interpreter from 3.11 to 3.10