### PR TITLE
fix: Use full commit hash for guppy

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,7 +11,7 @@ guppy-runner = "guppy_runner.__main__:main"
 
 [tool.poetry.dependencies]
 python = "^3.10"
-guppy = { git = "git@github.com:CQCL/guppy.git", rev = "e0761ff" }
+guppy = { git = "git@github.com:CQCL/guppy.git", rev = "f52a5de95972d028167f5800d16573c178c9e2be" }
 logging = "^0.4.9.6"
 
 [tool.poetry.group.dev.dependencies]


### PR DESCRIPTION
And update to the one used in #13 .